### PR TITLE
Basic Event Title Limiter Added

### DIFF
--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -37,7 +37,7 @@ class EventCard extends StatelessWidget {
           title: Text(
             event.title.toString(),
             style: Theme.of(context).textTheme.headlineMedium,
-            maxLines: 2,
+            maxLines: 4,
             overflow: TextOverflow.ellipsis,
           ),
           subtitle: Text(

--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -37,6 +37,8 @@ class EventCard extends StatelessWidget {
           title: Text(
             event.title.toString(),
             style: Theme.of(context).textTheme.headlineMedium,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
           subtitle: Text(
             event.displayDate(),

--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -28,12 +28,6 @@ class EventDialog extends StatelessWidget {
     launchUrl(uri);
   }
 
-  void _titleLimiter(String eventTitle) async {
-    if (eventTitle.length > 60) {
-      eventTitle = "${eventTitle.substring(0, 60)}...";
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return AlertDialog(

--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -28,6 +28,12 @@ class EventDialog extends StatelessWidget {
     launchUrl(uri);
   }
 
+  void _titleLimiter(String eventTitle) async {
+    if (eventTitle.length > 60) {
+      eventTitle = "${eventTitle.substring(0, 60)}...";
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -52,7 +58,9 @@ class EventDialog extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(event.title.toString(),
-                    style: Theme.of(context).textTheme.headlineLarge),
+                    style: Theme.of(context).textTheme.headlineLarge,
+                    maxLines: 5,
+                    overflow: TextOverflow.ellipsis),
                 const SizedBox(height: 5),
                 Text(
                   event.eventType.toString(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -529,10 +529,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -577,18 +577,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -950,10 +950,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -1022,26 +1022,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
+      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.1"
+    version: "1.24.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
+      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.3"
   tuple:
     dependency: transitive
     description:
@@ -1178,6 +1178,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1259,5 +1267,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0-0"


### PR DESCRIPTION
Event Titles shown on their card and dialog pop-up have now been limited through use of maxLines and overflow modifiers of the Text data type. This also includes Updated Dependencies.

This is intended to be a last resort fix to the title issue. If this is accepted as a genuine fix, there will also be the related issue with having to display the full title somewhere for the user to see if it is severely long enough. Politely asking the managers of Hendrix Today to put a message that tells submissions to write concise titles would also help to reduce the number of occasions this issue may rear its head.
