### PR TITLE
Title Limiter Improvements

### DIFF
--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -37,7 +37,7 @@ class EventCard extends StatelessWidget {
           title: Text(
             event.title.toString(),
             style: Theme.of(context).textTheme.headlineMedium,
-            maxLines: 4,
+            maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
           subtitle: Text(

--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -16,20 +16,9 @@ import 'package:add_2_calendar/add_2_calendar.dart';
 /// To ensure Users can see titles of extreme length, this widget has been
 /// made a Stateful Widget.
 
-class EventDialog extends StatefulWidget {
+class EventDialog extends StatelessWidget {
   const EventDialog({super.key, required this.event});
   final HDXEvent event;
-
-  // Ignore This
-  @override
-  State createState() => _EventState(event: event);
-}
-
-class _EventState extends State<EventDialog> {
-  _EventState({required this.event});
-  final HDXEvent event;
-  int maximumLines = 4;
-  bool extended = false;
 
   /// Attempts to begin a draft email to the [HDXEvent.contactEmail].
   ///
@@ -66,12 +55,7 @@ class _EventState extends State<EventDialog> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  event.title.toString(),
-                  style: Theme.of(context).textTheme.headlineLarge,
-                  maxLines: maximumLines,
-                ),
-                _buildTextButton(),
+                EventDialogTitle(event: event),
                 Text(
                   event.eventType.toString(),
                   style: Theme.of(context)
@@ -173,6 +157,36 @@ class _EventState extends State<EventDialog> {
   /// This widget creates an elipsis TextButton that only appears
   /// when the maximum title length has been exceeded. This will
   /// allow users to click and view the whole title should they desire.
+}
+
+class EventDialogTitle extends StatefulWidget {
+  const EventDialogTitle({super.key, required this.event});
+  final HDXEvent event;
+
+  @override
+  // If there is a better way to do this. Let me know!
+  // ignore: no_logic_in_create_state
+  State createState() => _EventTitleState(event: event);
+}
+
+class _EventTitleState extends State<EventDialogTitle> {
+  _EventTitleState({required this.event});
+  final HDXEvent event;
+  int maximumLines = 4;
+  bool extended = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Text(
+        event.title.toString(),
+        style: Theme.of(context).textTheme.headlineLarge,
+        maxLines: maximumLines,
+      ),
+      _buildTextButton()
+    ]);
+  }
+
   Widget _buildTextButton() {
     if (event.title.length < 80 || extended) {
       return const SizedBox.shrink();

--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -12,9 +12,24 @@ import 'package:add_2_calendar/add_2_calendar.dart';
 /// This dialog holds all [HDXEvent] information accessible to the user, so its
 /// layout must be thoughtfully planned. This widget conforms to the Hendrix
 /// College style guide.
-class EventDialog extends StatelessWidget {
+///
+/// To ensure Users can see titles of extreme length, this widget has been
+/// made a Stateful Widget.
+
+class EventDialog extends StatefulWidget {
   const EventDialog({super.key, required this.event});
   final HDXEvent event;
+
+  // Ignore This
+  @override
+  State createState() => _EventState(event: event);
+}
+
+class _EventState extends State<EventDialog> {
+  _EventState({required this.event});
+  final HDXEvent event;
+  int maximumLines = 4;
+  bool extended = false;
 
   /// Attempts to begin a draft email to the [HDXEvent.contactEmail].
   ///
@@ -51,11 +66,12 @@ class EventDialog extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(event.title.toString(),
-                    style: Theme.of(context).textTheme.headlineLarge,
-                    maxLines: 5,
-                    overflow: TextOverflow.ellipsis),
-                const SizedBox(height: 5),
+                Text(
+                  event.title.toString(),
+                  style: Theme.of(context).textTheme.headlineLarge,
+                  maxLines: maximumLines,
+                ),
+                _buildTextButton(),
                 Text(
                   event.eventType.toString(),
                   style: Theme.of(context)
@@ -152,5 +168,31 @@ class EventDialog extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  /// This widget creates an elipsis TextButton that only appears
+  /// when the maximum title length has been exceeded. This will
+  /// allow users to click and view the whole title should they desire.
+  Widget _buildTextButton() {
+    if (event.title.length < 80 || extended) {
+      return const SizedBox.shrink();
+    } else {
+      return TextButton(
+          onPressed: () {
+            setState(() {
+              maximumLines = 20;
+              extended = true;
+            });
+          },
+          child: const Text(
+            "...",
+            style: TextStyle(
+              // No remaining TextStyles remained, this was the only option.
+              color: Color.fromARGB(255, 202, 81, 39),
+              fontWeight: FontWeight.bold,
+              fontSize: 25,
+            ),
+          ));
+    }
   }
 }

--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -55,7 +55,7 @@ class EventDialog extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                EventDialogTitle(event: event),
+                EventDialogTitle(eventTitle: event.title),
                 Text(
                   event.eventType.toString(),
                   style: Theme.of(context)
@@ -160,18 +160,18 @@ class EventDialog extends StatelessWidget {
 }
 
 class EventDialogTitle extends StatefulWidget {
-  const EventDialogTitle({super.key, required this.event});
-  final HDXEvent event;
+  const EventDialogTitle({super.key, required this.eventTitle});
+  final String eventTitle;
 
   @override
   // If there is a better way to do this. Let me know!
   // ignore: no_logic_in_create_state
-  State createState() => _EventTitleState(event: event);
+  State createState() => _EventTitleState(eventTitle: eventTitle);
 }
 
 class _EventTitleState extends State<EventDialogTitle> {
-  _EventTitleState({required this.event});
-  final HDXEvent event;
+  _EventTitleState({required this.eventTitle});
+  final String eventTitle;
   int maximumLines = 4;
   bool extended = false;
 
@@ -179,7 +179,7 @@ class _EventTitleState extends State<EventDialogTitle> {
   Widget build(BuildContext context) {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Text(
-        event.title.toString(),
+        eventTitle.toString(),
         style: Theme.of(context).textTheme.headlineLarge,
         maxLines: maximumLines,
       ),
@@ -188,7 +188,7 @@ class _EventTitleState extends State<EventDialogTitle> {
   }
 
   Widget _buildTextButton() {
-    if (event.title.length < 80 || extended) {
+    if (eventTitle.length < 80 || extended) {
       return const SizedBox.shrink();
     } else {
       return TextButton(


### PR DESCRIPTION
The limiter on Event Titles has been improved to allow button functionality. That is, when a user wants to see the full length of an event title that has exceed the maximum line limit, they will be able to press the new TextButton disguised as ellipsis to view it. This button only appears on events with such limit breaking titles and will immediately disappear after the title has been extended to its full length.

This also resulted in the Event Dialog Stateless Widget becoming a Stateful Widget so that the title changes could be seen in real time.
