### PR TITLE
Limiting Size of Event Dialog

### DIFF
--- a/lib/widgets/event_dialog.dart
+++ b/lib/widgets/event_dialog.dart
@@ -40,6 +40,30 @@ class EventDialog extends StatelessWidget {
     launchUrl(uri);
   }
 
+  _dialogSize(BuildContext context, String orientation) {
+    var screenHeight = MediaQuery.of(context).size.height;
+    var screenWidth = MediaQuery.of(context).size.width;
+    const originalHeight = 25.0;
+    const originalWidth = 50.0;
+
+    if (orientation.contains("v")) {
+      if (screenHeight >= 1200) {
+        return 300.0 + originalHeight;
+      } else {
+        return originalHeight;
+      }
+    }
+    if (orientation.contains("h")) {
+      if (screenWidth >= 500) {
+        return 150.0 + originalWidth;
+      } else {
+        return originalWidth;
+      }
+    }
+
+    return screenWidth;
+  }
+
   String _parseDescription(desc) {
     final List<String> rtItems = [];
     final Document doc = parse(desc);
@@ -68,7 +92,9 @@ class EventDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      insetPadding: const EdgeInsets.symmetric(vertical: 25, horizontal: 50),
+      insetPadding: EdgeInsets.symmetric(
+          vertical: _dialogSize(context, "v"),
+          horizontal: _dialogSize(context, "h")),
       shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(0.0))),
       titlePadding: const EdgeInsets.fromLTRB(0, 24, 18, 0),


### PR DESCRIPTION
The Event Dialog pop-up has been limited to a certain width and height depending on the screen size of a device.
