### PR TITLE
Search on Home

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:hendrix_today_app/objects/app_state.dart';
-//import 'package:hendrix_today_app/objects/event.dart';
+import 'package:hendrix_today_app/objects/event.dart';
 import 'package:hendrix_today_app/objects/event_type.dart';
 import 'package:hendrix_today_app/widgets/event_list.dart';
 import 'package:hendrix_today_app/widgets/floating_nav_buttons.dart';
@@ -24,10 +24,10 @@ class _HomeScreenState extends State<HomeScreen> {
   EventTypeFilter eventTypeFilter = EventTypeFilter.all;
   String searchQuery = "";
 
-  /* List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
+  List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
       .where((HDXEvent e) =>
           e.containsString(searchQuery) && e.inPostingRange(DateTime.now()))
-      .toList(); */
+      .toList();
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +37,7 @@ class _HomeScreenState extends State<HomeScreen> {
             event.eventType.matchesFilter(eventTypeFilter) &&
             event.inPostingRange(DateTime.now()))
         .toList();
-    //final searchResults = _applySearchFilter(appState.events);
+    final searchResults = _applySearchFilter(appState.events);
 
     return Scaffold(
       appBar: AppBar(
@@ -62,23 +62,25 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
               const Spacer(),
               const SizedBox(width: 5),
-              TextField(
-                key: const Key('SearchInput'),
-                onChanged: (newQuery) => setState(() {
-                  searchQuery = newQuery;
-                }),
-                decoration: InputDecoration(
-                    labelText: 'Enter search query',
-                    labelStyle: Theme.of(context)
-                        .textTheme
-                        .labelLarge
-                        ?.copyWith(
-                            color: Theme.of(context).colorScheme.tertiary),
-                    focusColor: Theme.of(context).colorScheme.primary,
-                    suffixIcon: const Icon(Icons.search),
-                    iconColor: Theme.of(context).colorScheme.secondary),
-              ),
             ],
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 8.0),
+            child: TextField(
+              key: const Key('SearchInput'),
+              onChanged: (newQuery) => setState(() {
+                searchQuery = newQuery;
+              }),
+              decoration: InputDecoration(
+                  labelText: 'Search',
+                  labelStyle: Theme.of(context)
+                      .textTheme
+                      .labelLarge
+                      ?.copyWith(color: Theme.of(context).colorScheme.tertiary),
+                  focusColor: Theme.of(context).colorScheme.primary,
+                  suffixIcon: const Icon(Icons.search),
+                  iconColor: Theme.of(context).colorScheme.secondary),
+            ),
           ),
           if (homePageEvents.isNotEmpty)
             Flexible(
@@ -153,7 +155,7 @@ class _FilterDropdown extends StatelessWidget {
   }
 }
 
-/*class _EmptySearchLabel extends StatelessWidget {
+class _EmptySearchLabel extends StatelessWidget {
   const _EmptySearchLabel();
 
   @override
@@ -165,4 +167,4 @@ class _FilterDropdown extends StatelessWidget {
       ),
     );
   }
-}*/
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:hendrix_today_app/objects/app_state.dart';
-import 'package:hendrix_today_app/objects/event.dart';
 import 'package:hendrix_today_app/objects/event_type.dart';
 import 'package:hendrix_today_app/widgets/event_list.dart';
 import 'package:hendrix_today_app/widgets/floating_nav_buttons.dart';
@@ -24,20 +23,15 @@ class _HomeScreenState extends State<HomeScreen> {
   EventTypeFilter eventTypeFilter = EventTypeFilter.all;
   String searchQuery = "";
 
-  List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
-      .where((HDXEvent e) =>
-          e.containsString(searchQuery) && e.inPostingRange(DateTime.now()))
-      .toList();
-
   @override
   Widget build(BuildContext context) {
     final appState = Provider.of<AppState>(context);
     final homePageEvents = appState.events
         .where((event) =>
             event.eventType.matchesFilter(eventTypeFilter) &&
-            event.inPostingRange(DateTime.now()))
+            event.inPostingRange(DateTime.now()) &&
+            event.containsString(searchQuery))
         .toList();
-    final searchResults = _applySearchFilter(appState.events);
 
     return Scaffold(
       appBar: AppBar(
@@ -72,7 +66,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 searchQuery = newQuery;
               }),
               decoration: InputDecoration(
-                  labelText: 'Search',
+                  labelText: ' Search',
                   labelStyle: Theme.of(context)
                       .textTheme
                       .labelLarge
@@ -150,20 +144,6 @@ class _FilterDropdown extends StatelessWidget {
           selectedItemBuilder: (context) =>
               dropdownItemsList(context, selectedStyle),
         ),
-      ),
-    );
-  }
-}
-
-class _EmptySearchLabel extends StatelessWidget {
-  const _EmptySearchLabel();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 10),
-        child: Text("There are no events containing that query."),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:hendrix_today_app/objects/app_state.dart';
-import 'package:hendrix_today_app/objects/event.dart';
+//import 'package:hendrix_today_app/objects/event.dart';
 import 'package:hendrix_today_app/objects/event_type.dart';
 import 'package:hendrix_today_app/widgets/event_list.dart';
 import 'package:hendrix_today_app/widgets/floating_nav_buttons.dart';
-
 import 'package:provider/provider.dart';
 
 /// The home page for Hendrix Today.
@@ -25,10 +24,10 @@ class _HomeScreenState extends State<HomeScreen> {
   EventTypeFilter eventTypeFilter = EventTypeFilter.all;
   String searchQuery = "";
 
-  List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
+  /* List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
       .where((HDXEvent e) =>
           e.containsString(searchQuery) && e.inPostingRange(DateTime.now()))
-      .toList();
+      .toList(); */
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +37,8 @@ class _HomeScreenState extends State<HomeScreen> {
             event.eventType.matchesFilter(eventTypeFilter) &&
             event.inPostingRange(DateTime.now()))
         .toList();
-    final searchResults = _applySearchFilter(appState.events);
+    //final searchResults = _applySearchFilter(appState.events);
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
@@ -62,6 +62,22 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
               const Spacer(),
               const SizedBox(width: 5),
+              TextField(
+                key: const Key('SearchInput'),
+                onChanged: (newQuery) => setState(() {
+                  searchQuery = newQuery;
+                }),
+                decoration: InputDecoration(
+                    labelText: 'Enter search query',
+                    labelStyle: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(
+                            color: Theme.of(context).colorScheme.tertiary),
+                    focusColor: Theme.of(context).colorScheme.primary,
+                    suffixIcon: const Icon(Icons.search),
+                    iconColor: Theme.of(context).colorScheme.secondary),
+              ),
             ],
           ),
           if (homePageEvents.isNotEmpty)
@@ -137,7 +153,7 @@ class _FilterDropdown extends StatelessWidget {
   }
 }
 
-class _EmptySearchLabel extends StatelessWidget {
+/*class _EmptySearchLabel extends StatelessWidget {
   const _EmptySearchLabel();
 
   @override
@@ -149,4 +165,4 @@ class _EmptySearchLabel extends StatelessWidget {
       ),
     );
   }
-}
+}*/

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:hendrix_today_app/objects/app_state.dart';
+import 'package:hendrix_today_app/objects/event.dart';
 import 'package:hendrix_today_app/objects/event_type.dart';
 import 'package:hendrix_today_app/widgets/event_list.dart';
 import 'package:hendrix_today_app/widgets/floating_nav_buttons.dart';
@@ -22,6 +23,12 @@ class _HomeScreenState extends State<HomeScreen> {
   /// The [EventTypeFilter] to apply to the home page event list; defaults to
   /// [EventTypeFilter.all].
   EventTypeFilter eventTypeFilter = EventTypeFilter.all;
+  String searchQuery = "";
+
+  List<HDXEvent> _applySearchFilter(List<HDXEvent> events) => events
+      .where((HDXEvent e) =>
+          e.containsString(searchQuery) && e.inPostingRange(DateTime.now()))
+      .toList();
 
   @override
   Widget build(BuildContext context) {
@@ -31,10 +38,7 @@ class _HomeScreenState extends State<HomeScreen> {
             event.eventType.matchesFilter(eventTypeFilter) &&
             event.inPostingRange(DateTime.now()))
         .toList();
-    /*
-    final isEverythingRead =
-        homePageEvents.every((event) => appState.hasBeenRead(event.id));
-    */
+    final searchResults = _applySearchFilter(appState.events);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
@@ -57,19 +61,6 @@ class _HomeScreenState extends State<HomeScreen> {
                 }),
               ),
               const Spacer(),
-              /* Removing the Readall button 
-              if (!isEverythingRead)
-                ElevatedButton(
-                  onPressed: () {
-                    final appState =
-                        Provider.of<AppState>(context, listen: false);
-                    for (final event in homePageEvents) {
-                      appState.markEventAsRead(event);
-                    }
-                  },
-                  child: const Icon(Icons.checklist_rtl),
-                ),
-                */
               const SizedBox(width: 5),
             ],
           ),
@@ -141,6 +132,20 @@ class _FilterDropdown extends StatelessWidget {
           selectedItemBuilder: (context) =>
               dropdownItemsList(context, selectedStyle),
         ),
+      ),
+    );
+  }
+}
+
+class _EmptySearchLabel extends StatelessWidget {
+  const _EmptySearchLabel();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 10),
+        child: Text("There are no events containing that query."),
       ),
     );
   }

--- a/lib/widgets/floating_nav_buttons.dart
+++ b/lib/widgets/floating_nav_buttons.dart
@@ -40,22 +40,12 @@ class FloatingNavButtons extends StatelessWidget {
           ),
         ),
         Container(
-          key: const Key('SearchButton'),
-          margin: const EdgeInsets.all(10),
-          child: FloatingActionButton.small(
-            heroTag: null,
-            onPressed: () => _navigate(context, '/search'),
-            backgroundColor: Theme.of(context).colorScheme.primary,
-            child: const Icon(Icons.search),
-          ),
-        ),
-        Container(
           key: const Key('ResourcesButton'),
           margin: const EdgeInsets.all(10),
           child: FloatingActionButton.small(
             heroTag: null,
             onPressed: () => _navigate(context, '/resources'),
-            backgroundColor: Theme.of(context).colorScheme.tertiary,
+            backgroundColor: Theme.of(context).colorScheme.primary,
             child: const Icon(Icons.info_outline),
           ),
         ),


### PR DESCRIPTION
Due to the similarities between the Search and Home page, it has been decided that we should try to just have one instead of both. As such, I've taken a scorched earth approach and simply put all of Search Page's code onto the Home page, while deleting the original Search Page along with all references to it. The original Home Page code has also  been overwritten by the Search Page code. There is no longer a Filter List, if the Filter List was to be kept, let me know!
