### PR TITLE
Deadline Appears on Event Card

### DIFF
--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -40,10 +40,7 @@ class EventCard extends StatelessWidget {
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
-          subtitle: Text(
-            event.displayDate(),
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
+          subtitle: _eventDeadline(context),
           onTap: () {
             showDialog(
               context: context,
@@ -61,5 +58,19 @@ class EventCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _eventDeadline(context) {
+    if (event.displayDeadline() != null) {
+      return Text(
+        "${event.displayDate()} - Deadline on ${event.displayDeadline()}",
+        style: Theme.of(context).textTheme.headlineSmall,
+      );
+    } else {
+      return Text(
+        event.displayDate(),
+        style: Theme.of(context).textTheme.headlineSmall,
+      );
+    }
   }
 }


### PR DESCRIPTION
Utilizing the extra whitespace on the Event Card, deadlines now appear next to the date of an event. The original idea appeared too discreet and too mysterious for a user to understand. So, I found a solution that directly solves this while also being unique to each event.
