### PR TITLE
Read/Unread Icon Changed

### DIFF
--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -54,9 +54,9 @@ class EventCard extends StatelessWidget {
           trailing: isRead
               ? null
               : Icon(
-                  Icons.new_releases,
+                  Icons.circle_rounded,
                   color: Theme.of(context).colorScheme.primary,
-                  size: 35,
+                  size: 21,
                 ),
         ),
       ),


### PR DESCRIPTION
During feedback, it was found that the previous icon for unread messages was unclear. After looking at icons for similar apps, I found that they use a simple dot to convey unread messages/emails/events etc. Therefore, I have changed it to a simple dot too. Sometimes, simple is better, and I hope that this is the case for these darn icons.
