### PR TITLE
Resource Screen Buttons now adjusted

### DIFF
--- a/lib/screens/resource_screen.dart
+++ b/lib/screens/resource_screen.dart
@@ -42,7 +42,6 @@ class ResourcesScreen extends StatelessWidget {
             children: <Widget>[
               const SizedBox(height: 10),
               ResourceButton(
-                  
                   key: const Key('SubmitEventButton'),
                   titleString: "submit event",
                   icon: Icons.add,
@@ -55,7 +54,8 @@ class ResourcesScreen extends StatelessWidget {
                   titleString: "reserve room",
                   icon: Icons.meeting_room,
                   color: Theme.of(context).colorScheme.tertiary,
-                  url: 'https://www.aaiscloud.com/HendrixC/events/EventReqForm.aspx?id=a7fcc274-cc27-4980-8cf2-ee1581df1879#viewmode%3Dedit'),
+                  url:
+                      'https://www.aaiscloud.com/HendrixC/events/EventReqForm.aspx?id=a7fcc274-cc27-4980-8cf2-ee1581df1879#viewmode%3Dedit'),
               const SizedBox(height: 10),
               ResourceButton(
                   key: const Key('CafMenuButton'),

--- a/lib/widgets/resource_button.dart
+++ b/lib/widgets/resource_button.dart
@@ -50,48 +50,45 @@ class ResourceButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 100,
-      width: 300,
+    return Container(
+      padding: const EdgeInsets.fromLTRB(55.0, 8.0, 55.0, 8.0),
       child: Card(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
         elevation: 5,
         color: color,
         child: ListTile(
-          minVerticalPadding: 30.0,
-          title: AutoSizeText(
-            // new addition here
-            maxFontSize: 20,
-            titleString,
-            style: Theme.of(context).textTheme.displayMedium,
-            textAlign: TextAlign.center,
-          ),
-          leading:
-              Icon(icon, size: 60, color: Theme.of(context).iconTheme.color),
-          onTap: () => showDialog<String>(
-            context: context,
-            builder: (BuildContext context) => AlertDialog(
-              title: const Text('This is an external link. Continue?'),
-              actions: <Widget>[
-                TextButton(
-                  onPressed: () => Navigator.pop(context, 'Cancel'),
-                  child: const Text('Cancel'),
-                ),
-                TextButton(
-                  onPressed: () => _tryLaunchUrl(url),
-                  child: const Text('OK'),
-                ),
-              ],
+            title: AutoSizeText(
+              // new addition here
+              maxFontSize: 20,
+              titleString,
+              style: Theme.of(context).textTheme.displayMedium,
+              textAlign: TextAlign.center,
             ),
-          )
+            leading:
+                Icon(icon, size: 60, color: Theme.of(context).iconTheme.color),
+            onTap: () => showDialog<String>(
+                  context: context,
+                  builder: (BuildContext context) => AlertDialog(
+                    title: const Text('This is an external link. Continue?'),
+                    actions: <Widget>[
+                      TextButton(
+                        onPressed: () => Navigator.pop(context, 'Cancel'),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () => _tryLaunchUrl(url),
+                        child: const Text('OK'),
+                      ),
+                    ],
+                  ),
+                )
 /*            _tryLaunchUrl(url).then(
                 (value) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                       content: Text(value),
                     )));
                     */
-          
-          
-        ),
+
+            ),
       ),
     );
   }

--- a/lib/widgets/toggle_bar.dart
+++ b/lib/widgets/toggle_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:hendrix_today_app/widgets/root_app.dart';
 import 'package:hendrix_today_app/objects/theme_provider.dart';
 import 'package:provider/provider.dart';
 


### PR DESCRIPTION
The Resource Screen Buttons besides the Dark/Light Mode Toggle have been made to adjust to the size of the text within instead of being a large fixed size within a SizedBox. This may not be a complete solution as the padding size may differ between devices of different resolution.
